### PR TITLE
allow 24 time format

### DIFF
--- a/sunrise-config-schema.coffee
+++ b/sunrise-config-schema.coffee
@@ -11,4 +11,9 @@ module.exports = {
       description: "longitude"
       type: "number"
       default: -122.03476
+    timeFormat:
+      description: "Change the time display format"
+      type: "string"
+      enum: ["default", "12h", "24h"]
+      default: "default"
 }

--- a/sunrise.coffee
+++ b/sunrise.coffee
@@ -80,6 +80,7 @@ module.exports = (env) ->
       @timezone = @config.timezone.trim().replace(/\ /g , "_")
       @utcOffset = parseInt(@config.utcOffset) * -1
       @attributes = _.cloneDeep(@attributes)
+      @timeFormatOptions = if @plugin.config.timeFormat == 'default' then {} else { hour12: @plugin.config.timeFormat == '12h' }
       @_initTimes()
 
       for attribute in @config.attributes
@@ -92,7 +93,7 @@ module.exports = (env) ->
             acronym: attribute.label ? label
 
           @_createGetter attribute.name, () =>
-            return Promise.resolve @_transformTimezone(@eventTimes[attribute.name]).toLocaleTimeString()
+            return Promise.resolve @_transformTimezone(@eventTimes[attribute.name]).toLocaleTimeString(undefined, @timeFormatOptions)
 
       super(@config)
 
@@ -102,7 +103,7 @@ module.exports = (env) ->
           @_initTimes()
           for attribute in @config.attributes
             do (attribute) =>
-              @emit attribute.name, @_transformTimezone(@eventTimes[attribute.name]).toLocaleTimeString()
+              @emit attribute.name, @_transformTimezone(@eventTimes[attribute.name]).toLocaleTimeString(undefined, @timeFormatOptions)
 
           scheduleUpdate()
         , @_getTimeTillTomorrow()


### PR DESCRIPTION
This PR allows to define the time format for the sunrise/sunset times.
By default is uses system default as before. With this change the user can explicitly set the time format to 12h or 24h if desired.